### PR TITLE
Patch 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,4 +13,8 @@
     "pngjs": "^0.4.0",
     "synaptic": "^0.1.7"
   }
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mateogianolio/mlp-character-recognition.git"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "canvas": "^1.2.1",
     "pngjs": "^0.4.0",
     "synaptic": "^0.1.7"
-  }
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/mateogianolio/mlp-character-recognition.git"


### PR DESCRIPTION
npm version 1.4.28 will complain if you if you do not have a repository field:

``` bash
~/.../mlp-character-recognition$ npm install
npm WARN package.json mlp-character-recognition@1.0.0 No repository field.
```

This will add the repository field.
